### PR TITLE
Fix execute_cpu running more cycles than requested

### DIFF
--- a/include/sgpl/algorithm/advance_core.hpp
+++ b/include/sgpl/algorithm/advance_core.hpp
@@ -1,0 +1,80 @@
+#pragma once
+#ifndef SGPL_ALGORITHM_ADVANCE_CORE_HPP_INCLUDE
+#define SGPL_ALGORITHM_ADVANCE_CORE_HPP_INCLUDE
+
+#include <cassert>
+#include <tuple>
+
+#include "../../../third-party/Empirical/include/emp/base/assert.hpp"
+#include "../../../third-party/Empirical/include/emp/base/macros.hpp"
+
+#include "../hardware/Core.hpp"
+#include "../program/Instruction.hpp"
+#include "../program/Program.hpp"
+#include "../utility/ByteEnumeration.hpp"
+
+namespace sgpl {
+
+// tried a dispatch table, seemed to do about the same or worse
+// https://eli.thegreenplace.net/2012/07/12/computed-goto-for-efficient-dispatch-tables
+template<typename Spec>
+__attribute__ ((hot))
+inline void advance_core(
+  sgpl::Core<Spec>& state,
+  const sgpl::Program<Spec>& program,
+  typename Spec::peripheral_t& peripheral
+) {
+
+  using library_t = typename Spec::library_t;
+
+  emp_assert( program.size() );
+
+  const auto& instruction = program[ state.GetProgramCounter() ];
+
+  emp_assert( instruction.op_code < library_t::GetSize() );
+
+  // can't use emp_assert due to obsucre macro error
+  #define SGPL_CASE_PAYLOAD(N) \
+    case N: \
+      if constexpr (N < library_t::GetSize()) { \
+        using Functor = typename library_t::template Operation<N>; \
+        Functor::template run<Spec>(state, instruction, program, peripheral);\
+      } else { \
+        assert( false && N ); \
+        __builtin_unreachable(); \
+      } \
+    break;
+
+    static_assert( library_t::GetSize() < 256 );
+
+  switch( instruction.op_code ) {
+
+    EMP_WRAP_EACH( SGPL_CASE_PAYLOAD, SGPL_BYTE_ENUMERATION )
+
+    default:
+      emp_assert( false, instruction.op_code );
+      __builtin_unreachable();
+
+  }
+
+  state.AdvanceProgramCounter( program.size() );
+
+};
+
+template<typename Spec>
+inline void advance_core(
+  sgpl::Core<Spec>& state,
+  const sgpl::Program<Spec>& program
+) {
+
+  using peripheral_t = typename Spec::peripheral_t;
+  peripheral_t peripheral;
+
+  advance_core<Spec>(state, program, peripheral);
+
+}
+
+
+} // namespace sgpl
+
+#endif // #ifndef SGPL_ALGORITHM_ADVANCE_CORE_HPP_INCLUDE

--- a/include/sgpl/algorithm/execute_core.hpp
+++ b/include/sgpl/algorithm/execute_core.hpp
@@ -2,132 +2,27 @@
 #ifndef SGPL_ALGORITHM_EXECUTE_CORE_HPP_INCLUDE
 #define SGPL_ALGORITHM_EXECUTE_CORE_HPP_INCLUDE
 
-#include <cassert>
-#include <tuple>
-
-#include "../../../third-party/Empirical/include/emp/base/assert.hpp"
-#include "../../../third-party/Empirical/include/emp/base/macros.hpp"
-
-#include "../hardware/Core.hpp"
-#include "../program/Instruction.hpp"
-#include "../program/Program.hpp"
-#include "../utility/ByteEnumeration.hpp"
+#include "execute_core_slice.hpp"
 
 namespace sgpl {
 
-// tried a dispatch table, seemed to do about the same or worse
-// https://eli.thegreenplace.net/2012/07/12/computed-goto-for-efficient-dispatch-tables
 template<typename Spec>
-__attribute__ ((hot))
-inline void advance_core(
-  sgpl::Core<Spec>& state,
-  const sgpl::Program<Spec>& program,
-  typename Spec::peripheral_t& peripheral
-) {
-
-  using library_t = typename Spec::library_t;
-
-  emp_assert( program.size() );
-
-  const auto& instruction = program[ state.GetProgramCounter() ];
-
-  emp_assert( instruction.op_code < library_t::GetSize() );
-
-  // can't use emp_assert due to obsucre macro error
-  #define SGPL_CASE_PAYLOAD(N) \
-    case N: \
-      if constexpr (N < library_t::GetSize()) { \
-        using Functor = typename library_t::template Operation<N>; \
-        Functor::template run<Spec>(state, instruction, program, peripheral);\
-      } else { \
-        assert( false && N ); \
-        __builtin_unreachable(); \
-      } \
-    break;
-
-    static_assert( library_t::GetSize() < 256 );
-
-  switch( instruction.op_code ) {
-
-    EMP_WRAP_EACH( SGPL_CASE_PAYLOAD, SGPL_BYTE_ENUMERATION )
-
-    default:
-      emp_assert( false, instruction.op_code );
-      __builtin_unreachable();
-
-  }
-
-  state.AdvanceProgramCounter( program.size() );
-
-};
-
-template<typename Spec>
-size_t execute_core(
-  sgpl::Core<Spec>& state,
-  const sgpl::Program<Spec>& program,
-  typename Spec::peripheral_t& peripheral,
-  size_t max_cycles
-) {
-
-  /**
-   * We need to make sure that the GlobalJumpTable is populated
-   * /except/ when the program has no modules.
-   * In this case, when there are no GlobalAnchors within the program,
-   * it is acceptable for the GlobalJumpTable to be empty.
-   */
-  emp_assert(
-    state.GetGlobalJumpTable().GetSize()
-    || !program.HasGlobalAnchor(),
-    "Global anchors not initialized! "
-    "Hint: call Cpu.InitializeAnchors()",
-    state.GetGlobalJumpTable().GetSize(),
-    program.HasGlobalAnchor()
-  );
-  max_cycles = std::min(Spec::switch_steps, max_cycles);
-
-  size_t i;
-  for (i = 0; i < max_cycles && !state.HasTerminated(); ++i) {
-    advance_core<Spec>(state, program, peripheral);
-  }
-  return i;
-
-};
-
-template<typename Spec>
+[[deprecated("Use execute_core_slice instead.")]]
 inline size_t execute_core(
   sgpl::Core<Spec>& state,
   const sgpl::Program<Spec>& program,
   typename Spec::peripheral_t& peripheral
 ) {
-
-  return execute_core(state, program, peripheral, Spec::switch_steps);
-
+  return execute_core_slice(state, program, peripheral);
 };
 
 template<typename Spec>
-inline void advance_core(
-  sgpl::Core<Spec>& state,
-  const sgpl::Program<Spec>& program
-) {
-
-  using peripheral_t = typename Spec::peripheral_t;
-  peripheral_t peripheral;
-
-  advance_core<Spec>(state, program, peripheral);
-
-}
-
-template<typename Spec>
+[[deprecated("Use execute_core_slice instead.")]]
 inline size_t execute_core(
   sgpl::Core<Spec>& state,
   const sgpl::Program<Spec>& program
 ) {
-
-  using peripheral_t = typename Spec::peripheral_t;
-  peripheral_t peripheral;
-
-  return execute_core<Spec>(state, program, peripheral);
-
+  return execute_core_slice<Spec>(state, program);
 }
 
 

--- a/include/sgpl/algorithm/execute_core.hpp
+++ b/include/sgpl/algorithm/execute_core.hpp
@@ -65,7 +65,8 @@ template<typename Spec>
 size_t execute_core(
   sgpl::Core<Spec>& state,
   const sgpl::Program<Spec>& program,
-  typename Spec::peripheral_t& peripheral
+  typename Spec::peripheral_t& peripheral,
+  size_t max_cycles
 ) {
 
   /**
@@ -82,12 +83,24 @@ size_t execute_core(
     state.GetGlobalJumpTable().GetSize(),
     program.HasGlobalAnchor()
   );
+  max_cycles = std::min(Spec::switch_steps, max_cycles);
 
   size_t i;
-  for (i = 0; i < Spec::switch_steps && !state.HasTerminated(); ++i) {
+  for (i = 0; i < max_cycles && !state.HasTerminated(); ++i) {
     advance_core<Spec>(state, program, peripheral);
   }
   return i;
+
+};
+
+template<typename Spec>
+inline size_t execute_core(
+  sgpl::Core<Spec>& state,
+  const sgpl::Program<Spec>& program,
+  typename Spec::peripheral_t& peripheral
+) {
+
+  return execute_core(state, program, peripheral, Spec::switch_steps);
 
 };
 

--- a/include/sgpl/algorithm/execute_core_cycles.hpp
+++ b/include/sgpl/algorithm/execute_core_cycles.hpp
@@ -1,0 +1,63 @@
+#pragma once
+#ifndef SGPL_ALGORITHM_EXECUTE_CORE_CYCLES_HPP_INCLUDE
+#define SGPL_ALGORITHM_EXECUTE_CORE_CYCLES_HPP_INCLUDE
+
+#include "../../../third-party/Empirical/include/emp/base/assert.hpp"
+#include "../../../third-party/Empirical/include/emp/base/macros.hpp"
+
+#include "../hardware/Core.hpp"
+#include "../program/Instruction.hpp"
+#include "../program/Program.hpp"
+
+#include "advance_core.hpp"
+
+namespace sgpl {
+
+template<typename Spec>
+inline size_t execute_core_cycles(
+  sgpl::Core<Spec>& state,
+  const sgpl::Program<Spec>& program,
+  typename Spec::peripheral_t& peripheral,
+  const size_t max_cycles
+) {
+
+  /**
+   * We need to make sure that the GlobalJumpTable is populated
+   * /except/ when the program has no modules.
+   * In this case, when there are no GlobalAnchors within the program,
+   * it is acceptable for the GlobalJumpTable to be empty.
+   */
+  emp_assert(
+    state.GetGlobalJumpTable().GetSize()
+    || !program.HasGlobalAnchor(),
+    "Global anchors not initialized! "
+    "Hint: call Cpu.InitializeAnchors()",
+    state.GetGlobalJumpTable().GetSize(),
+    program.HasGlobalAnchor()
+  );
+
+  size_t c;
+  for (c = 0; c < max_cycles && !state.HasTerminated(); ++c) {
+    advance_core<Spec>(state, program, peripheral);
+  }
+  return c;
+
+};
+
+template<typename Spec>
+inline size_t execute_core_cycles(
+  sgpl::Core<Spec>& state,
+  const sgpl::Program<Spec>& program,
+  const size_t max_cycles
+) {
+
+  using peripheral_t = typename Spec::peripheral_t;
+  peripheral_t peripheral;
+
+  return execute_core_cycles<Spec>(state, program, peripheral, max_cycles);
+
+}
+
+} // namespace sgpl
+
+#endif // #ifndef SGPL_ALGORITHM_EXECUTE_CORE_CYCLES_HPP_INCLUDE

--- a/include/sgpl/algorithm/execute_core_slice.hpp
+++ b/include/sgpl/algorithm/execute_core_slice.hpp
@@ -1,0 +1,36 @@
+#pragma once
+#ifndef SGPL_ALGORITHM_EXECUTE_CORE_SLICE_HPP_INCLUDE
+#define SGPL_ALGORITHM_EXECUTE_CORE_SLICE_HPP_INCLUDE
+
+#include "execute_core_cycles.hpp"
+
+namespace sgpl {
+
+template<typename Spec>
+inline size_t execute_core_slice(
+  sgpl::Core<Spec>& state,
+  const sgpl::Program<Spec>& program,
+  typename Spec::peripheral_t& peripheral
+) {
+
+  return execute_core_cycles(state, program, peripheral, Spec::switch_steps);
+
+};
+
+template<typename Spec>
+inline size_t execute_core_slice(
+  sgpl::Core<Spec>& state,
+  const sgpl::Program<Spec>& program
+) {
+
+  using peripheral_t = typename Spec::peripheral_t;
+  peripheral_t peripheral;
+
+  return execute_core_slice<Spec>(state, program, peripheral);
+
+}
+
+
+} // namespace sgpl
+
+#endif // #ifndef SGPL_ALGORITHM_EXECUTE_CORE_SLICE_HPP_INCLUDE

--- a/include/sgpl/algorithm/execute_cpu.hpp
+++ b/include/sgpl/algorithm/execute_cpu.hpp
@@ -22,11 +22,17 @@ void execute_cpu(
 ) {
 
   emp_assert( program.size() );
+  const size_t end_cycles = state.GetCyclesSinceConstruction() + cycles;
 
-  for (size_t i{}; i < cycles && state.HasActiveCore(); ++i) {
+  while (state.GetCyclesSinceConstruction() < end_cycles && state.HasActiveCore()) {
 
     auto& core = state.GetActiveCore();
-    const size_t num_cycles = execute_core<Spec>(core, program, peripheral);
+    const size_t num_cycles = execute_core<Spec>(
+      core,
+      program,
+      peripheral,
+      end_cycles - state.GetCyclesSinceConstruction()
+    );
     state.AdvanceCycleClock( num_cycles );
     if ( core.HasTerminated() ) state.KillActiveCore();
 

--- a/include/sgpl/algorithm/execute_cpu.hpp
+++ b/include/sgpl/algorithm/execute_cpu.hpp
@@ -2,57 +2,38 @@
 #ifndef SGPL_ALGORITHM_EXECUTE_CPU_HPP_INCLUDE
 #define SGPL_ALGORITHM_EXECUTE_CPU_HPP_INCLUDE
 
-#include <tuple>
-
-#include "../hardware/Cpu.hpp"
-#include "../program/Program.hpp"
-#include "../spec/Spec.hpp"
-#include "../utility/EmptyType.hpp"
-
-#include "execute_core.hpp"
+#include "execute_cpu_n_slices.hpp"
 
 namespace sgpl {
 
 template<typename Spec>
-void execute_cpu(
-  const size_t cycles,
+[[deprecated("Use execute_cpu_n_slices instead.")]]
+inline void execute_cpu(
+  const size_t max_slices,
   sgpl::Cpu<Spec>& state,
   const sgpl::Program<Spec>& program,
   typename Spec::peripheral_t& peripheral
 ) {
-
-  emp_assert( program.size() );
-  const size_t end_cycles = state.GetCyclesSinceConstruction() + cycles;
-
-  while (state.GetCyclesSinceConstruction() < end_cycles && state.HasActiveCore()) {
-
-    auto& core = state.GetActiveCore();
-    const size_t num_cycles = execute_core<Spec>(
-      core,
-      program,
-      peripheral,
-      end_cycles - state.GetCyclesSinceConstruction()
-    );
-    state.AdvanceCycleClock( num_cycles );
-    if ( core.HasTerminated() ) state.KillActiveCore();
-
-    state.TryActivateNextCore();
-  }
-
+  return execute_cpu_n_slices(
+    max_slices,
+    state,
+    program,
+    peripheral
+  );
 }
 
-template<typename Spec=sgpl::Spec<>>
-void execute_cpu(
-  const size_t cycles,
+template<typename Spec>
+[[deprecated("Use execute_cpu_n_slices instead.")]]
+inline void execute_cpu(
+  const size_t max_slices,
   sgpl::Cpu<Spec>& state,
   const sgpl::Program<Spec>& program
 ) {
-
-  using peripheral_t = typename Spec::peripheral_t;
-  peripheral_t peripheral;
-
-  execute_cpu<Spec>( cycles, state, program, peripheral );
-
+  return execute_cpu_n_slices(
+    max_slices,
+    state,
+    program
+  );
 }
 
 } // namespace sgpl

--- a/include/sgpl/algorithm/execute_cpu_n_cycles.hpp
+++ b/include/sgpl/algorithm/execute_cpu_n_cycles.hpp
@@ -1,0 +1,61 @@
+#pragma once
+#ifndef SGPL_ALGORITHM_EXECUTE_CPU_N_CYCLES_HPP_INCLUDE
+#define SGPL_ALGORITHM_EXECUTE_CPU_N_CYCLES_HPP_INCLUDE
+
+#include <algorithm>
+
+#include "../hardware/Cpu.hpp"
+#include "../program/Program.hpp"
+#include "../spec/Spec.hpp"
+#include "../utility/EmptyType.hpp"
+
+#include "execute_core.hpp"
+
+namespace sgpl {
+
+template<typename Spec>
+void execute_cpu_n_cycles(
+  const size_t max_cycles,
+  sgpl::Cpu<Spec>& state,
+  const sgpl::Program<Spec>& program,
+  typename Spec::peripheral_t& peripheral
+) {
+
+  emp_assert( program.size() );
+
+  for (size_t c{}; c < max_cycles && state.HasActiveCore(); /*incr c inside*/) {
+
+    auto& core = state.GetActiveCore();
+    const size_t try_cycles = std::min(Spec::switch_steps, max_cycles - c);
+    const size_t res_cycles = execute_core_cycles<Spec>(
+      core,
+      program,
+      peripheral,
+      try_cycles
+    );
+    state.AdvanceCycleClock( res_cycles );
+    c += res_cycles;
+    if ( core.HasTerminated() ) state.KillActiveCore();
+
+    state.TryActivateNextCore();
+  }
+
+}
+
+template<typename Spec=sgpl::Spec<>>
+inline void execute_cpu_n_cycles(
+  const size_t cycles,
+  sgpl::Cpu<Spec>& state,
+  const sgpl::Program<Spec>& program
+) {
+
+  using peripheral_t = typename Spec::peripheral_t;
+  peripheral_t peripheral;
+
+  execute_cpu_n_cycles<Spec>( cycles, state, program, peripheral );
+
+}
+
+} // namespace sgpl
+
+#endif // #ifndef SGPL_ALGORITHM_EXECUTE_CPU_N_CYCLES_HPP_INCLUDE

--- a/include/sgpl/algorithm/execute_cpu_n_slices.hpp
+++ b/include/sgpl/algorithm/execute_cpu_n_slices.hpp
@@ -1,0 +1,58 @@
+#pragma once
+#ifndef SGPL_ALGORITHM_EXECUTE_CPU_N_SLICES_HPP_INCLUDE
+#define SGPL_ALGORITHM_EXECUTE_CPU_N_SLICES_HPP_INCLUDE
+
+#include <tuple>
+
+#include "../hardware/Cpu.hpp"
+#include "../program/Program.hpp"
+#include "../spec/Spec.hpp"
+#include "../utility/EmptyType.hpp"
+
+#include "execute_core_slice.hpp"
+
+namespace sgpl {
+
+template<typename Spec>
+void execute_cpu_n_slices(
+  const size_t max_slices,
+  sgpl::Cpu<Spec>& state,
+  const sgpl::Program<Spec>& program,
+  typename Spec::peripheral_t& peripheral
+) {
+
+  emp_assert( program.size() );
+
+  for (size_t s{}; s < max_slices && state.HasActiveCore(); ++s) {
+
+    auto& core = state.GetActiveCore();
+    const size_t num_cycles = execute_core_slice<Spec>(
+      core,
+      program,
+      peripheral
+    );
+    state.AdvanceCycleClock( num_cycles );
+    if ( core.HasTerminated() ) state.KillActiveCore();
+
+    state.TryActivateNextCore();
+  }
+
+}
+
+template<typename Spec=sgpl::Spec<>>
+inline void execute_cpu_n_slices(
+  const size_t max_slices,
+  sgpl::Cpu<Spec>& state,
+  const sgpl::Program<Spec>& program
+) {
+
+  using peripheral_t = typename Spec::peripheral_t;
+  peripheral_t peripheral;
+
+  execute_cpu_n_slices<Spec>( max_slices, state, program, peripheral );
+
+}
+
+} // namespace sgpl
+
+#endif // #ifndef SGPL_ALGORITHM_EXECUTE_CPU_N_SLICES_HPP_INCLUDE

--- a/tests/algorithm/Makefile
+++ b/tests/algorithm/Makefile
@@ -1,6 +1,11 @@
+TEST_NAMES += advance_core
 TEST_NAMES += drag_to
 TEST_NAMES += execute_core
+TEST_NAMES += execute_core_cycles
+TEST_NAMES += execute_core_slice
 TEST_NAMES += execute_cpu
+TEST_NAMES += execute_cpu_n_cycles
+TEST_NAMES += execute_cpu_n_slices
 TEST_NAMES += inst_indel_copy
 TEST_NAMES += module_indel_copy
 TEST_NAMES += mutate_bits

--- a/tests/algorithm/advance_core.cpp
+++ b/tests/algorithm/advance_core.cpp
@@ -1,0 +1,9 @@
+#include "Catch/single_include/catch2/catch.hpp"
+
+#include "sgpl/algorithm/advance_core.hpp"
+
+TEST_CASE("Test advance_core") {
+
+  // TODO flesh out stub test
+
+}

--- a/tests/algorithm/execute_core_cycles.cpp
+++ b/tests/algorithm/execute_core_cycles.cpp
@@ -1,0 +1,9 @@
+#include "Catch/single_include/catch2/catch.hpp"
+
+#include "sgpl/algorithm/execute_core_cycles.hpp"
+
+TEST_CASE("Test execute_core_cycles") {
+
+  // TODO flesh out stub test
+
+}

--- a/tests/algorithm/execute_core_slice.cpp
+++ b/tests/algorithm/execute_core_slice.cpp
@@ -1,0 +1,9 @@
+#include "Catch/single_include/catch2/catch.hpp"
+
+#include "sgpl/algorithm/execute_core_slice.hpp"
+
+TEST_CASE("Test execute_core_slice") {
+
+  // TODO flesh out stub test
+
+}

--- a/tests/algorithm/execute_cpu_n_cycles.cpp
+++ b/tests/algorithm/execute_cpu_n_cycles.cpp
@@ -1,0 +1,9 @@
+#include "Catch/single_include/catch2/catch.hpp"
+
+#include "sgpl/algorithm/execute_cpu_n_cycles.hpp"
+
+TEST_CASE("Test execute_cpu_n_cycles") {
+
+  // TODO flesh out stub test
+
+}

--- a/tests/algorithm/execute_cpu_n_slices.cpp
+++ b/tests/algorithm/execute_cpu_n_slices.cpp
@@ -1,0 +1,9 @@
+#include "Catch/single_include/catch2/catch.hpp"
+
+#include "sgpl/algorithm/execute_cpu_n_slices.hpp"
+
+TEST_CASE("Test execute_cpu_n_slices") {
+
+  // TODO flesh out stub test
+
+}


### PR DESCRIPTION
`execute_cpu()` has a `cycles` parameter, but instead of actually corresponding to the number of executed cycles, it corresponds to the number of calls to `execute_core()`, each of which can run up to 8 cycles by default. This changes it so that `execute_cpu` uses the cycle clock to track when to stop calling `execute_core`, and also passes it the maximum number of cycles to execute in case it's less than `Spec::switch_steps` (i.e. 8).